### PR TITLE
Fix #18; Display the URL field.

### DIFF
--- a/ui/src/components/MetadataDetails.tsx
+++ b/ui/src/components/MetadataDetails.tsx
@@ -18,7 +18,6 @@ export const MetadataDetails = ({ meta, hidePapers }: Props) => {
                 <strong>CORD UID:</strong><br />
                 {meta.cord_uid}
             </Gap>
-            <strong></strong>
             {meta.doi ? (
                 <>
                     <Gap position="below" size="md">

--- a/ui/src/components/MetadataDetails.tsx
+++ b/ui/src/components/MetadataDetails.tsx
@@ -14,6 +14,11 @@ export const MetadataDetails = ({ meta, hidePapers }: Props) => {
     const nonEmptyPaperIds = !hidePapers ? meta.paper_ids.filter(pid => pid !== "") : [];
     return (
         <>
+            <Gap position="below" size="md">
+                <strong>CORD UID:</strong><br />
+                {meta.cord_uid}
+            </Gap>
+            <strong></strong>
             {meta.doi ? (
                 <>
                     <Gap position="below" size="md">
@@ -29,6 +34,12 @@ export const MetadataDetails = ({ meta, hidePapers }: Props) => {
                         </a>
                     </Gap>
                 </>
+            ) : null}
+            {meta.url ? (
+                <Gap position="below" size="md">
+                    <strong>URL:</strong><br />
+                    <a href={meta.url} rel="noopener">{meta.url}</a>
+                </Gap>
             ) : null}
             {nonEmptyPaperIds.length > 0 ? (
                 <Gap position="below" size="md">

--- a/ui/src/magellan/models.ts
+++ b/ui/src/magellan/models.ts
@@ -53,6 +53,7 @@ export interface Paper {
 
 export interface MetadataEntry {
     id: string;
+    cord_uid: string;
     paper_ids: string[];
     source: string;
     title: string;
@@ -68,4 +69,5 @@ export interface MetadataEntry {
     who_covidence_number: string;
     has_full_text: boolean;
     collection: string;
+    url: string;
 }


### PR DESCRIPTION
This PR adds the `cord_uid` and `url` fields to the metadata
details view.

The URL is often the same as that for the DOI, and often resolves
to the same place the paper link does, so it's of marginal benefit
to the UI.